### PR TITLE
Fixed the template to allow building the project and loading the module without errors

### DIFF
--- a/root/name-ux/name-ux.gradle
+++ b/root/name-ux/name-ux.gradle
@@ -11,6 +11,7 @@ niagaraModule {
   preferredSymbol = "{%= preferredSymbol %}"
   moduleName = "{%= name %}"
   runtimeProfile = "ux"
+  version = "{%= version %}"
 }
 
 dependencies {

--- a/template.js
+++ b/template.js
@@ -266,6 +266,7 @@ exports.template = function (grunt, init, done) {
     props.keywords = [];
     props.year = new Date().getFullYear();
     props.devDependencies = {
+	  "requirejs" : "^2.1",
       "grunt": "~0.4.1",
       "grunt-niagara": "^0.1.20"
     };


### PR DESCRIPTION
- **Added the `version` attribute to the gradle file:** The template generates a gradle file without a module version, causing the module to fail to load in the station when I follow the instructions in docDeveloper.pdf.
- **Added the requirejs library as a development depenedency in package.json:** When the command `npm install` is issued, require.js fails to download because it is not resolved as a dependency somehow.
